### PR TITLE
feat(bpdm-cert): set up docker hub image for bpdm certificate management application

### DIFF
--- a/.github/workflows/docker-hub-build.yaml
+++ b/.github/workflows/docker-hub-build.yaml
@@ -1,0 +1,93 @@
+################################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
+
+name: Build - Docker image (SemVer)
+
+on:
+  push:
+    branches:
+      - main
+    # trigger events for SemVer like tags
+    tags:
+      - 'v*.*.*'
+      - 'v*.*.*-*'
+  pull_request:
+    branches:
+      - main
+
+env:
+  IMAGE_NAMESPACE: "tractusx"
+  IMAGE_NAME: "bpdm-certificate-management"
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # Create SemVer or ref tags dependent of trigger event
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
+          # Automatically prepare image tags; See action docs for more examples.
+          # semver patter will generate tags like these for example :1 :1.2 :1.2.3
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: DockerHub login
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          # Use existing DockerHub credentials present as secrets
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: ./docker
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ${{ steps.meta.outputs.tags }},
+            ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+
+      # https://github.com/peter-evans/dockerhub-description
+      # Important step to push image description to DockerHub
+      - name: Update Docker Hub description
+        if: github.event_name != 'pull_request'
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          # readme-filepath defaults to toplevel README.md, Only necessary if you have a dedicated file with your 'Notice for docker images'
+          readme-filepath: DOCKER_NOTICE.md
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          repository: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}

--- a/docker/DOCKER_NOTICE.md
+++ b/docker/DOCKER_NOTICE.md
@@ -1,0 +1,37 @@
+## Notice for Docker image
+
+DockerHub: [https://hub.docker.com/r/tractusx/bpdm-certificate-management](https://hub.docker.com/r/tractusx/bpdm-certificate-management)
+
+Eclipse Tractus-X product(s) installed within the image:
+
+**Bpdm Certificate Management**
+
+Eclipse Tractus-X product(s) installed within the image:
+
+- GitHub: https://github.com/eclipse-tractusx/bpdm-certificate-management 
+- Project home: https://projects.eclipse.org/projects/automotive.tractusx
+- Bpdm Certificate Management Dockerfile: https://github.com/eclipse-tractusx/bpdm-certificate-management/blob/main/Dockerfile
+- Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/bpdm-certificate-management/blob/main/LICENSE)
+
+
+**Used base image**
+
+- [eclipse-temurin:17-jre-alpine](https://github.com/adoptium/containers)
+- Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
+- Eclipse Temurin Project: https://projects.eclipse.org/projects/adoptium.temurin
+- Additional information about the Eclipse Temurin images: https://github.com/docker-library/repo-info/tree/master/repos/eclipse-temurin
+
+
+As with all Docker images, these likely also contain other software which may be under other licenses
+(such as Bash, etc. from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
+
+As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies with any relevant licenses for all software contained within.
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm-certificate-management

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,22 @@
+FROM maven:3.8.7-eclipse-temurin-17 AS build
+COPY ../../ /home/app
+WORKDIR /home/app
+RUN mvn clean package -DskipTests
+
+FROM eclipse-temurin:17-jre-alpine
+# Adding wget for the health check
+RUN apk --no-cache add wget
+COPY --from=build /home/app/target/bpdm-certificate-management.jar /usr/local/lib/bpdmCertificate/app.jar
+RUN apk update && apk upgrade --no-cache libssl3 libcrypto3
+ARG USERNAME=bpdmCertificate
+ARG USERID=10001
+ARG GID=10002
+RUN addgroup -g $GID -S $USERNAME
+RUN adduser -u $USERID -S $USERNAME $USERNAME
+USER $USERNAME
+WORKDIR /usr/local/lib/bpdmCertificate
+EXPOSE 8086
+# Health check instruction
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget --quiet --tries=1 --spider http://localhost:8086/actuator/health || exit 1
+ENTRYPOINT ["java","-jar","app.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -29,14 +29,16 @@
     </parent>
 
     <groupId>org.eclipse.tractusx</groupId>
-    <artifactId>bdpm-certificate-management</artifactId>
+    <artifactId>bpdm-certificate-management</artifactId>
     <version>0.0.1-SNAPSHOT</version>
-    <name>bdpm-certificate-management</name>
-    <description>bdpm-certificate-management</description>
+    <name>bpdm-certificate-management</name>
+    <description>bpdm-certificate-management</description>
 
     <properties>
         <java.version>17</java.version>
         <kotlin.version>1.8.22</kotlin.version>
+        <springdoc.version>2.0.0</springdoc.version>
+        <kotlinlogging.version>2.1.23</kotlinlogging.version>
     </properties>
 
     <dependencies>
@@ -94,12 +96,6 @@
             <artifactId>jackson-databind-nullable</artifactId>
             <version>0.2.6</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/io.springfox/springfox-boot-starter -->
-        <dependency>
-            <groupId>io.springfox</groupId>
-            <artifactId>springfox-boot-starter</artifactId>
-            <version>3.0.0</version>
-        </dependency>
         <!-- https://mvnrepository.com/artifact/javax.annotation/javax.annotation-api -->
         <dependency>
             <groupId>javax.annotation</groupId>
@@ -112,6 +108,27 @@
             <artifactId>javax.servlet-api</artifactId>
             <version>4.0.1</version>
             <scope>provided</scope>
+        </dependency>
+        <!-- Kotlin wrapper for slf4j (Logging)-->
+        <dependency>
+            <groupId>io.github.microutils</groupId>
+            <artifactId>kotlin-logging-jvm</artifactId>
+            <version>${kotlinlogging.version}</version>
+        </dependency>
+        <!-- OpenAPI 3 auto API documentation library for Spring Boot -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>${springdoc.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-common</artifactId>
+            <version>${springdoc.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
     </dependencies>
 
@@ -126,6 +143,9 @@
     </pluginRepositories>
 
     <build>
+        <!-- Name jar without version to make it easier to reference it during CI/CD -->
+        <finalName>bpdm-certificate-management</finalName>
+
         <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
         <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
         <plugins>
@@ -171,10 +191,10 @@
                             <inputSpec>${project.basedir}/src/main/resources/static/BpdmCertificate.yaml</inputSpec>
                             <generatorName>kotlin-spring</generatorName>
                             <configOptions>
-                                <basePackage>org.eclipse.tractusx.bdpmcertificatemanagement</basePackage>
-                                <apiPackage>org.eclipse.tractusx.bdpmcertificatemanagement.controller</apiPackage>
-                                <modelPackage>org.eclipse.tractusx.bdpmcertificatemanagement.model</modelPackage>
-                                <configPackage>org.eclipse.tractusx.bdpmcertificatemanagement.config</configPackage>
+                                <basePackage>org.eclipse.tractusx.bpdmcertificatemanagement</basePackage>
+                                <apiPackage>org.eclipse.tractusx.bpdmcertificatemanagement.controller</apiPackage>
+                                <modelPackage>org.eclipse.tractusx.bpdmcertificatemanagement.model</modelPackage>
+                                <configPackage>org.eclipse.tractusx.bpdmcertificatemanagement.config</configPackage>
                                 <delegatePattern>true</delegatePattern>
                                 <interfaceOnly>false</interfaceOnly>
                                 <modelNameSuffix>Dto</modelNameSuffix>

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/Application.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/Application.kt
@@ -16,7 +16,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.eclipse.tractusx.bdpmcertificatemanagement
+package org.eclipse.tractusx.bpdmcertificatemanagement
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/config/LandingPageConfig.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/config/LandingPageConfig.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.bpdmcertificatemanagement.config
+
+import org.springdoc.core.properties.SwaggerUiConfigProperties
+import org.springframework.context.annotation.Configuration
+import mu.KotlinLogging
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry
+
+@Configuration
+class LandingPageConfig(
+    val swaggerProperties: SwaggerUiConfigProperties
+) : WebMvcConfigurer {
+
+    private val logger = KotlinLogging.logger { }
+
+    override fun addViewControllers(registry: ViewControllerRegistry) {
+        val redirectUri = swaggerProperties.path
+        logger.info { "Set landing page to path '$redirectUri'" }
+        registry.addRedirectViewController("/", redirectUri)
+    }
+}

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/config/OpenApiConfiguration.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/config/OpenApiConfiguration.kt
@@ -17,20 +17,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.eclipse.tractusx.bdpmcertificatemanagement.controller
+package org.eclipse.tractusx.bpdmcertificatemanagement.config
 
-import org.springframework.http.MediaType
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 
-@RestController
-@RequestMapping("api/catena/certificate", produces = [MediaType.APPLICATION_JSON_VALUE])
-class CertificateController {
-
-    @GetMapping("/{bpn}")
-    fun getCertificateWelcome(
-        @PathVariable bpn: String
-    ) = "Hello, you requested for certificate $bpn!!"
+@Configuration
+class OpenApiConfiguration {
+    @Bean
+    fun apiInfo(): OpenAPI {
+        return OpenAPI()
+            .info(
+                Info()
+                    .title("BPDM Certificate Management")
+                    .description("Service that manages and shares business partner certificates")
+                    .version("0.0.1")
+            )
+    }
 }

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/controller/CertificateController.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/controller/CertificateController.kt
@@ -16,16 +16,21 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.eclipse.tractusx.bdpmcertificatemanagement
 
-import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
+package org.eclipse.tractusx.bpdmcertificatemanagement.controller
 
-@SpringBootTest
-class ApplicationTests {
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
 
-    @Test
-    fun contextLoads() {
-    }
+@RestController
+@RequestMapping("api/catena/certificate", produces = [MediaType.APPLICATION_JSON_VALUE])
+class CertificateController {
 
+    @GetMapping("/{bpn}")
+    fun getCertificateWelcome(
+        @PathVariable bpn: String
+    ) = "Hello, you requested for certificate $bpn!!"
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,3 +18,36 @@
 #
 
 
+#
+# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+##
+#Springdoc swagger configuration
+springdoc.api-docs.enabled=true
+springdoc.api-docs.path=/docs/api-docs
+springdoc.swagger-ui.disable-swagger-default-url=true
+springdoc.swagger-ui.path=/ui/swagger-ui
+springdoc.swagger-ui.show-common-extensions=true
+##
+# Change default port
+server.port=8086
+##
+#Enable actuator endpoints
+management.endpoint.health.probes.enabled=true
+management.health.livenessState.enabled=true
+management.health.readinessState.enabled=true

--- a/src/main/resources/static/BpdmCertificate.yaml
+++ b/src/main/resources/static/BpdmCertificate.yaml
@@ -19,7 +19,8 @@
 openapi: "3.0.2"
 info:
   title: BPDM Certificate Management
-  version: "1.0"
+  description: Service that manages and shares business partner certificates
+  version: "0.0.1"
 servers:
   - url: https://localhost:8080
 paths:

--- a/src/test/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/ApplicationTests.kt
+++ b/src/test/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/ApplicationTests.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.tractusx.bpdmcertificatemanagement
+
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class ApplicationTests {
+
+    @Test
+    fun contextLoads() {
+    }
+
+}


### PR DESCRIPTION
## Description
Added code for github flow to create docker hub image for application.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
