### PR TITLE
fix(bpdm-cert): set up docker hub image for application

### DIFF
--- a/.github/workflows/docker-hub-build.yaml
+++ b/.github/workflows/docker-hub-build.yaml
@@ -72,7 +72,8 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
-          context: ./docker
+          context: .
+          file: docker/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ${{ steps.meta.outputs.tags }},

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM maven:3.8.7-eclipse-temurin-17 AS build
-COPY ../../ /home/app
+COPY . /home/app
 WORKDIR /home/app
 RUN mvn clean package -DskipTests
 


### PR DESCRIPTION

## Description
Fixed docker file for correct file path to create latest image on dockerhub

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
