### PR TITLE
fix(bpdm-cert): set up docker hub image

### DIFF
--- a/.github/workflows/docker-hub-build.yaml
+++ b/.github/workflows/docker-hub-build.yaml
@@ -88,7 +88,7 @@ jobs:
         uses: peter-evans/dockerhub-description@v3
         with:
           # readme-filepath defaults to toplevel README.md, Only necessary if you have a dedicated file with your 'Notice for docker images'
-          readme-filepath: DOCKER_NOTICE.md
+          readme-filepath: docker/DOCKER_NOTICE.md
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
           repository: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}


### PR DESCRIPTION
## Description
Fix file path for DOCKER_NOTICE.md

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
