### PR TITLE
feat(bpdm-cert): created metadata endpoints for certificate types

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,24 +16,26 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 ################################################################################
-##
-#Springdoc swagger configuration
-springdoc.api-docs.enabled=true
-springdoc.api-docs.path=/docs/api-docs
-springdoc.swagger-ui.disable-swagger-default-url=true
-springdoc.swagger-ui.path=/ui/swagger-ui
-springdoc.swagger-ui.show-common-extensions=true
-##
-# Change default port
-server.port=8086
-##
-#Enable actuator endpoints
-management.endpoint.health.probes.enabled=true
-management.health.livenessState.enabled=true
-management.health.readinessState.enabled=true
-##
-spring.datasource.url=jdbc:postgresql://localhost:5432/bpdm_certificates
-spring.datasource.driverClassName=org.postgresql.Driver
-spring.datasource.username=bpdm_certificates
-spring.datasource.password=
-spring.jpa.hibernate.ddl-auto=update
+## In order to run bpdm-certificate-management with profile `local` for development purposes
+services:
+  postgres:
+    image: postgres:14.2
+    container_name: bpdm-certificate-postgres
+    environment:
+      POSTGRES_USER: bpdm_certificates
+      POSTGRES_PASSWORD:
+      POSTGRES_DB: bpdm_certificates
+      POSTGRES_HOST_AUTH_METHOD: trust
+    healthcheck:
+      test: [ 'CMD-SHELL', 'pg_isready -U bpdm_certificates' ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    ports:
+      - "5432:5432"
+    volumes:
+      - bpdm-certificate-postgres-data:/var/lib/postgresql/data
+
+volumes:
+  bpdm-certificate-postgres-data:
+    name: bpdm-certificate-postgres-data

--- a/pom.xml
+++ b/pom.xml
@@ -63,14 +63,18 @@
             <artifactId>kotlin-stdlib</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/io.swagger.core.v3/swagger-annotations -->
         <dependency>
@@ -167,12 +171,19 @@
                     </args>
                     <compilerPlugins>
                         <plugin>spring</plugin>
+                        <plugin>jpa</plugin>
                     </compilerPlugins>
+                    <jvmTarget>17</jvmTarget>
                 </configuration>
                 <dependencies>
                     <dependency>
                         <groupId>org.jetbrains.kotlin</groupId>
                         <artifactId>kotlin-maven-allopen</artifactId>
+                        <version>${kotlin.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-maven-noarg</artifactId>
                         <version>${kotlin.version}</version>
                     </dependency>
                 </dependencies>
@@ -190,15 +201,6 @@
                         <configuration>
                             <inputSpec>${project.basedir}/src/main/resources/static/BpdmCertificate.yaml</inputSpec>
                             <generatorName>kotlin-spring</generatorName>
-                            <configOptions>
-                                <basePackage>org.eclipse.tractusx.bpdmcertificatemanagement</basePackage>
-                                <apiPackage>org.eclipse.tractusx.bpdmcertificatemanagement.controller</apiPackage>
-                                <modelPackage>org.eclipse.tractusx.bpdmcertificatemanagement.model</modelPackage>
-                                <configPackage>org.eclipse.tractusx.bpdmcertificatemanagement.config</configPackage>
-                                <delegatePattern>true</delegatePattern>
-                                <interfaceOnly>false</interfaceOnly>
-                                <modelNameSuffix>Dto</modelNameSuffix>
-                            </configOptions>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/controller/MetadataApi.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/controller/MetadataApi.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.bpdmcertificatemanagement.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import org.eclipse.tractusx.bpdmcertificatemanagement.dto.CertificateTypeDto
+import org.eclipse.tractusx.bpdmcertificatemanagement.dto.request.PaginationRequest
+import org.eclipse.tractusx.bpdmcertificatemanagement.dto.response.PageDto
+import org.springdoc.core.annotations.ParameterObject
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.service.annotation.GetExchange
+import org.springframework.web.service.annotation.HttpExchange
+import org.springframework.web.service.annotation.PostExchange
+import javax.validation.Valid
+
+@RequestMapping("/api/catena", produces = [MediaType.APPLICATION_JSON_VALUE])
+@HttpExchange("/api/catena")
+interface MetadataApi {
+
+    @Operation(
+        summary = "Register a new certificate type",
+        operationId = "setCertificateType",
+        description = "Register a new certificate type.",
+        responses = [
+            ApiResponse(responseCode = "200", description = "Successfully created"),
+            ApiResponse(responseCode = "400", description = "Malformed URL", content = [Content()]),
+            ApiResponse(responseCode = "409", description = "Type already exists", content = [Content()])
+        ]
+    )
+    @PostMapping("/certificate-types")
+    @PostExchange("/certificate-types")
+    fun setCertificateType(@Parameter(description = "", required = true) @Valid @RequestBody certificateTypeDto: CertificateTypeDto): CertificateTypeDto
+
+
+    @Operation(
+        summary = "Get certificate types",
+        operationId = "getCertificateTypes",
+        description = "Get a list of all currently registered certificate types.",
+        responses = [
+            ApiResponse(responseCode = "200", description = "List of registered certificate types, or can be empty"),
+            ApiResponse(responseCode = "400", description = "Malformed URL")
+        ]
+    )
+    @GetMapping("/certificate-types")
+    @GetExchange("/certificate-types")
+    fun getCertificateTypes(@ParameterObject paginationRequest: PaginationRequest): PageDto<CertificateTypeDto>
+
+}

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/controller/MetadataController.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/controller/MetadataController.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.bpdmcertificatemanagement.controller
+
+import org.eclipse.tractusx.bpdmcertificatemanagement.dto.CertificateTypeDto
+import org.eclipse.tractusx.bpdmcertificatemanagement.dto.request.PaginationRequest
+import org.eclipse.tractusx.bpdmcertificatemanagement.dto.response.PageDto
+import org.eclipse.tractusx.bpdmcertificatemanagement.service.MetadataService
+import org.springframework.data.domain.PageRequest
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+public open class MetadataController(
+    val metadataService: MetadataService
+): MetadataApi {
+    override fun setCertificateType(certificateTypeDto: CertificateTypeDto): CertificateTypeDto {
+        return metadataService.createCertificateType(certificateTypeDto)
+    }
+
+    override fun getCertificateTypes(paginationRequest: PaginationRequest): PageDto<CertificateTypeDto> {
+        return metadataService.getCertificateTypes(PageRequest.of(paginationRequest.page, paginationRequest.size))
+    }
+
+}

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/dto/CertificateTypeDto.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/dto/CertificateTypeDto.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.bpdmcertificatemanagement.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdmcertificatemanagement.dto.openapidescription.CertificateTypeDescription
+
+@Schema(description = CertificateTypeDescription.header)
+data class CertificateTypeDto(
+    @get:Schema(description = CertificateTypeDescription.certificateType)
+    val certificateType: String,
+
+    @get:Schema(description = CertificateTypeDescription.certificateVersion)
+    val certificateVersion:String
+)

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/dto/openapidescription/CertificateTypeDescription.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/dto/openapidescription/CertificateTypeDescription.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.bpdmcertificatemanagement.dto.openapidescription
+
+object CertificateTypeDescription {
+    const val header = "An identifier type defines the name or type of certificate, such as " +
+            "IATF-16949,ISO-9001 etc. The certificate type ."
+    const val certificateType = "The technical identifier for certificate (unique for each certificate)."
+    const val certificateVersion = "The number represent version of certificate."
+}

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/dto/request/PaginationRequest.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/dto/request/PaginationRequest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.bpdmcertificatemanagement.dto.request
+
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.PositiveOrZero
+
+@Schema(description = "Defines pagination information for requesting collection results")
+data class PaginationRequest(
+
+    @field:Parameter(
+        description = "Number of page to get results from", schema =
+        Schema(defaultValue = "0"))
+    @field:PositiveOrZero
+    val page: Int=0,
+
+    @field:Parameter(description = "Size of each page", schema =
+    Schema(defaultValue = "10"))
+    @field:Min(0)
+    @field:Max(100)
+    val size: Int=10
+)

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/dto/response/PageDto.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/dto/response/PageDto.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.bpdmcertificatemanagement.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Paginated collection of results")
+data class PageDto<T>(
+
+    @get:Schema(description = "Total number of all results in all pages")
+    val totalElements: Long,
+
+    @get:Schema(description = "Total number pages")
+    val totalPages: Int,
+
+    @get:Schema(description = "Current page number")
+    val page: Int,
+
+    @get:Schema(description = "Number of results in the page")
+    val contentSize: Int,
+
+    @get:Schema(description = "Collection of results in the page")
+    val content: Collection<T>
+)

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/entity/BaseEntity.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/entity/BaseEntity.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.bpdmcertificatemanagement.entity
+
+import jakarta.persistence.*
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.*
+
+@MappedSuperclass
+abstract class BaseEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "certificate_sequence")
+    @SequenceGenerator(name = "certificate_sequence", sequenceName = "certificate_sequence", allocationSize = 1)
+    @Column(name = "id", nullable = false, updatable = false, insertable = false)
+    val id: Long = 0,
+
+    @Column(name = "uuid", nullable = false, updatable = false, unique = true, columnDefinition = "uuid")
+    val uuid: UUID = UUID.randomUUID(),
+
+    @Column(updatable = false, nullable = false, name = "CREATED_AT")
+    @CreationTimestamp
+    val createdAt: Instant = Instant.now().truncatedTo(ChronoUnit.MICROS),
+
+    @Column(nullable = false, name = "UPDATED_AT")
+    @UpdateTimestamp
+    val updatedAt: Instant = Instant.now().truncatedTo(ChronoUnit.MICROS)
+)

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/entity/CertificateTypeDB.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/entity/CertificateTypeDB.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.bpdmcertificatemanagement.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "certificate_types")
+class CertificateTypeDB(
+    @Column(name = "certificate_type", nullable = false)
+    val certificateType: String,
+
+    @Column(name = "certificate_version", nullable = false)
+    val certificateVersion: String
+):BaseEntity()

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/exception/CertificateAlreadyExists.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/exception/CertificateAlreadyExists.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.bpdmcertificatemanagement.exception
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ResponseStatus
+
+@ResponseStatus(HttpStatus.CONFLICT)
+class CertificateAlreadyExists(
+    objectType: String,
+    identifier: String
+): RuntimeException("$objectType with the following identifier already exists: $identifier")

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/repository/CertificateTypeRepository.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/repository/CertificateTypeRepository.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.bpdmcertificatemanagement.repository
+
+import org.eclipse.tractusx.bpdmcertificatemanagement.entity.CertificateTypeDB
+import org.springframework.data.repository.CrudRepository
+import org.springframework.data.repository.PagingAndSortingRepository
+
+interface CertificateTypeRepository:PagingAndSortingRepository<CertificateTypeDB, Long>,CrudRepository<CertificateTypeDB, Long>{
+    fun findByCertificateType(key: String): CertificateTypeDB?
+}

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/service/MetadataService.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/service/MetadataService.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.bpdmcertificatemanagement.service
+
+import mu.KotlinLogging
+import org.eclipse.tractusx.bpdmcertificatemanagement.dto.CertificateTypeDto
+import org.eclipse.tractusx.bpdmcertificatemanagement.dto.response.PageDto
+import org.eclipse.tractusx.bpdmcertificatemanagement.entity.CertificateTypeDB
+import org.eclipse.tractusx.bpdmcertificatemanagement.exception.CertificateAlreadyExists
+import org.eclipse.tractusx.bpdmcertificatemanagement.repository.CertificateTypeRepository
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.eclipse.tractusx.bpdmcertificatemanagement.service.toDto
+
+@Service
+class MetadataService(
+    val certificateTypeRepository: CertificateTypeRepository,
+) {
+
+    private val logger = KotlinLogging.logger { }
+
+    fun createCertificateType(certificateTypeDto: CertificateTypeDto): CertificateTypeDto{
+        if (certificateTypeRepository.findByCertificateType(certificateTypeDto.certificateType) != null)
+            throw CertificateAlreadyExists(CertificateTypeDB::class.simpleName!!, certificateTypeDto.certificateType)
+
+        logger.info { "Create new Certificate Type with name ${certificateTypeDto.certificateType} and version ${certificateTypeDto.certificateVersion}" }
+
+        val entity = CertificateTypeDB(
+            certificateType = certificateTypeDto.certificateType,
+            certificateVersion = certificateTypeDto.certificateVersion
+        )
+
+        return certificateTypeRepository.save(entity).toDto()
+    }
+
+    fun getCertificateTypes(pageRequest: Pageable): PageDto<CertificateTypeDto> {
+        val page = certificateTypeRepository.findAll(pageRequest)
+        return page.toDto(page.content.map { it.toDto() })
+    }
+
+}

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/service/ResponseMappings.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/service/ResponseMappings.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.bpdmcertificatemanagement.service
+
+import org.eclipse.tractusx.bpdmcertificatemanagement.dto.CertificateTypeDto
+import org.eclipse.tractusx.bpdmcertificatemanagement.dto.response.PageDto
+import org.eclipse.tractusx.bpdmcertificatemanagement.entity.CertificateTypeDB
+import org.springframework.data.domain.Page
+
+fun <S, T> Page<S>.toDto(dtoContent: Collection<T>): PageDto<T> {
+    return PageDto(this.totalElements, this.totalPages, this.number, this.numberOfElements, dtoContent)
+}
+
+fun CertificateTypeDB.toDto(): CertificateTypeDto {
+    return CertificateTypeDto(certificateType, certificateVersion)
+}

--- a/src/main/resources/static/BpdmCertificate.yaml
+++ b/src/main/resources/static/BpdmCertificate.yaml
@@ -16,71 +16,450 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 ################################################################################
-openapi: "3.0.2"
+openapi: 3.0.2
 info:
   title: BPDM Certificate Management
   description: Service that manages and shares business partner certificates
-  version: "0.0.1"
+  version: v1.0.0
 servers:
-  - url: https://localhost:8080
+  - url: https://localhost:8086
+    description: Generated server url
 paths:
-  /api/catena/certificate:
+  /api/catena/certificate/{bpn}:
+    get:
+      tags:
+        - certificate-controller
+      summary: Get all certificates of a given BPN.
+      description: "This endpoint retrieves all certificates available for the BPN are returned. In case of BPNL,  all certificates available for the BPN are returned. In case of a BPNS, all certificates which either are assigned to the BPNS or the matching BPNL enclosing BPNS are returned."
+      operationId: getCertificatesPaginated
+      parameters:
+        - name: bpn
+          in: path
+          description: "BPN value, It can be BPNL, BPNS, BPNA"
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: page
+          in: query
+          description: Number of page to get results from
+          required: false
+          style: form
+          explode: true
+          schema:
+            minimum: 0
+            type: string
+            default: "0"
+        - name: size
+          in: query
+          description: Size of each page
+          required: false
+          style: form
+          explode: true
+          schema:
+            maximum: 100
+            minimum: 0
+            type: string
+            default: "10"
+      responses:
+        "200":
+          description: "Page of business partners matching the search criteria, may be empty"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageDtoCertificateDto'
+        "400":
+          description: On malformed pagination request
+  /api/catena/certificate/{bpn}/{certificateType}:
+    get:
+      tags:
+        - certificate-controller
+      summary: Get a specific certificate by certificate type for of a given BPN.
+      description: This endpoint retrieves certificate based on certificate type for provided business partner number.
+      operationId: getCertificateByType
+      parameters:
+        - name: bpn
+          in: path
+          description: "BPN value, It can be BPNL, BPNS, BPNA"
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: certificateType
+          in: path
+          description: Certificate type e.g. IATF-16949
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: "Certificate for business partner, can be the case where provided bpn could not be found"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CertificateDto'
+        "400":
+          description: On malformed request
+        "404":
+          description: Business Partner Number not found
+  /api/catena/certificate/simple/{bpn}/{certificateType}:
+    get:
+      tags:
+        - certificate-controller
+      summary: Gets info whether BPN is certified for a specific certificate type..
+      description: This endpoint checks whether a provided BPN is certified for a specific certificate type.
+      operationId: getCheckCertifiedBpn
+      parameters:
+        - name: bpn
+          in: path
+          description: "BPN value, It can be BPNL, BPNS, BPNA"
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: certificateType
+          in: path
+          description: Certificate type e.g. IATF-16949
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: "Certificate for business partner, can be the case where provided bpn could not be found"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CertificateCheckDto'
+        "400":
+          description: On malformed request
+        "404":
+          description: Business Partner Number not found
+  /api/catena/certificate/document/{cdID}:
+    get:
+      tags:
+        - document-controller
+      summary: Request a specific certificate document for a given BPN.
+      description: This endpoint call to request a specific certificate document for a given BPN.
+      operationId: getCertificateDocument
+      parameters:
+        - name: cdID
+          in: path
+          description: The internal certificate document ID
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Document for the given ID
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CertificateDocumentResponseDto'
+        "400":
+          description: Malformed URL
+        "401":
+          description: Unauthorized
+        "404":
+          description: cdID not found
+        "406":
+          description: Document not available
+  /api/catena/certificate/document:
     post:
       tags:
-        - Certificate Controller
-      summary: Create Certificate
-      operationId: createCertificate
+        - document-controller
+      summary: Provide a specific certificate document for a given BPN.
+      description: Use this API call to provide a specific certificate document for a given BPN.
+      operationId: setCertificateDocument
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Certificate'
+              $ref: '#/components/schemas/CertificateDocumentRequestDto'
+        required: true
       responses:
-        '200':
-          description: OK
+        "200":
+          description: Document for the given ID
           content:
-            'application/json':
+            application/json:
               schema:
-                $ref: '#/components/schemas/CertificateFullData'
-  /api/catena/certificate/{bpn}:
+                $ref: '#/components/schemas/CertificateDocumentResponseDto'
+        "400":
+          description: Malformed URL
+        "401":
+          description: Unauthorized
+        "404":
+          description: BPN not found
+        "406":
+          description: Document not available
+        "503":
+          description: Service not available
+  /api/catena/certificate-types:
     get:
       tags:
-        - Certificate Controller
-      summary: Retrieve Certificate
-      operationId: getCertificate
+        - metadata-controller
+      summary: Get certificate types
+      description: Get a list of all currently registered certificate types.
+      operationId: getCertificateTypes
       parameters:
-        - name: bpn
-          in: path
-          required: true
+        - name: page
+          in: query
+          description: Page of paged answer (0..n)
+          required: false
+          style: form
+          explode: true
           schema:
             type: string
+        - name: size
+          in: query
+          description: "Page size of paged answer, default is 10"
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            default: "10"
       responses:
-        '200':
-          description: OK
+        "200":
+          description: List of registered certificate types
           content:
-            'application/json':
+            application/json:
               schema:
-                $ref: '#/components/schemas/CertificateFullData'
-        '404':
-          description: NOT FOUND
+                $ref: '#/components/schemas/PageDtoCertificateTypesDto'
+        "400":
+          description: Malformed URL
+    post:
+      tags:
+        - metadata-controller
+      summary: Register a new certificate type
+      description: Register a new certificate type.
+      operationId: setCertificateType
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CertificateTypeDto'
+        required: true
+      responses:
+        "200":
+          description: Successfully created
+        "400":
+          description: Malformed URL
+        "409":
+          description: Type already exists
 components:
   schemas:
-    Certificate:
+    PageDtoCertificateDto:
+      type: object
+      properties:
+        totalElements:
+          type: integer
+          description: Total number of all results in all pages
+          format: int64
+        totalPages:
+          type: integer
+          description: Total number pages
+          format: int32
+        page:
+          type: integer
+          description: Current page number
+          format: int32
+        contentSize:
+          type: integer
+          description: Number of results in the page
+          format: int32
+        content:
+          type: array
+          description: Collection of results in the page
+          items:
+            $ref: '#/components/schemas/CertificateDto'
+      description: Paginated collection of results
+    CertificateDto:
+      type: object
+      properties:
+        businessPartnerNumber:
+          type: string
+          description: The business partner number
+        type:
+          $ref: '#/components/schemas/CertificateTypeDto'
+        registrationNumber:
+          type: string
+        areaOfApplication:
+          type: string
+        remark:
+          type: string
+          description: The certificate remark (can be a string or null)
+          nullable: true
+        enclosedSites:
+          type: array
+          items:
+            $ref: '#/components/schemas/EnclosedSiteDto'
+        validFrom:
+          type: string
+          format: date-time
+        validUntil:
+          type: string
+          format: date-time
+        issuer:
+          type: string
+        trustLevel:
+          type: string
+        validator:
+          $ref: '#/components/schemas/TrustValidatorDto'
+        uploader:
+          type: string
+        documentID:
+          type: string
+    CertificateTypeDto:
       type: object
       properties:
         certificateType:
           type: string
-          description: Type of the certificate
         certificateVersion:
           type: string
-          description: Version of the certificate
-    CertificateFullData:
-      allOf:
-        - $ref: '#/components/schemas/Certificate'
-        - type: object
-          properties:
-            certificateId:
-              type: integer
-              description: The ID of the certificate
-              format: int64
-      description: Full data of the certificate.
+      description: The certificates type and version for mentioned business partner
+    EnclosedSiteDto:
+      type: object
+      properties:
+        siteBPN:
+          type: string
+        areaOfApplication:
+          type: string
+    TrustValidatorDto:
+      type: object
+      properties:
+        validatorName:
+          type: string
+        validatorBPN:
+          type: string
+    CertificateDocumentDto:
+      type: object
+      properties:
+        certificateDocument:
+          type: string
+          description: Base64-encoded file contents
+          format: byte
+        certificateDocumentFormat:
+          type: string
+          description: "One of the Document format from options (PDF, PNG, JPG)"
+          enum:
+            - PDF
+            - PNG
+            - JPG
+    CertificateCheckDto:
+      type: object
+      properties:
+        businessPartnerBPN:
+          type: string
+          description: The business partner BPN
+        isCertified:
+          type: boolean
+          description: Indicates if the entity is certified for the specified certificate type
+        certificateValidUntil:
+          type: string
+          description: The date until which the certificate is valid
+          format: date-time
+        certificateTrustLevel:
+          type: string
+          description: The trust level of the certificate
+        certificateType:
+          $ref: '#/components/schemas/CertificateTypeDto'
+    CertificateDocumentResponseDto:
+      type: object
+      properties:
+        businessPartnerNumber:
+          type: string
+          description: The business partner number
+        type:
+          $ref: '#/components/schemas/CertificateTypeDto'
+        registrationNumber:
+          type: string
+        areaOfApplication:
+          type: string
+        remark:
+          type: string
+          description: The certificate remark (can be a string or null)
+          nullable: true
+        enclosedSites:
+          type: array
+          items:
+            $ref: '#/components/schemas/EnclosedSiteDto'
+        validFrom:
+          type: string
+          format: date-time
+        validUntil:
+          type: string
+          format: date-time
+        issuer:
+          type: string
+        trustLevel:
+          type: string
+        validator:
+          $ref: '#/components/schemas/TrustValidatorDto'
+        uploader:
+          type: string
+        document:
+          $ref: '#/components/schemas/CertificateDocumentDto'
+    CertificateDocumentRequestDto:
+      type: object
+      properties:
+        businessPartnerNumber:
+          type: string
+          description: The business partner number
+        type:
+          $ref: '#/components/schemas/CertificateTypeDto'
+        registrationNumber:
+          type: string
+        areaOfApplication:
+          type: string
+        remark:
+          type: string
+          description: The certificate remark (can be a string or null)
+          nullable: true
+        enclosedSites:
+          type: array
+          items:
+            $ref: '#/components/schemas/EnclosedSiteDto'
+        validFrom:
+          type: string
+          format: date-time
+        validUntil:
+          type: string
+          format: date-time
+        issuer:
+          type: string
+        trustLevel:
+          type: string
+        validator:
+          $ref: '#/components/schemas/TrustValidatorDto'
+        uploader:
+          type: string
+        document:
+          $ref: '#/components/schemas/CertificateDocumentDto'
+    PageDtoCertificateTypesDto:
+      type: object
+      properties:
+        totalElements:
+          type: integer
+          description: Total number of all results in all pages
+          format: int64
+        page:
+          type: integer
+          description: Current page
+          format: int32
+        contentSize:
+          type: integer
+          description: Size of the page
+          format: int32
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/CertificateTypeDto'


### PR DESCRIPTION
## Description
For Bpdm Certificate Management application, with this pull request created two endpoints to create and retrive certificate types under Metadata controller.

Fixes #6 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
