### PR TITLE
Feat (bpdm-certificate-management) - Added new endpoints for retrieving and inserting Base64

### DIFF
--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/controller/CertificateApi.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/controller/CertificateApi.kt
@@ -35,6 +35,7 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.web.service.annotation.GetExchange
 import org.springframework.web.service.annotation.HttpExchange
 import org.springframework.web.service.annotation.PostExchange
+import java.util.*
 
 @RequestMapping("/api/catena", produces = [MediaType.APPLICATION_JSON_VALUE])
 @HttpExchange("/api/catena")
@@ -55,7 +56,26 @@ interface CertificateApi {
     )
     @PostMapping("/certificate/document")
     @PostExchange("/certificate/document")
-    fun setCertificateDocument(@RequestBody certificateDocumentRequestDto: CertificateDocumentRequestDto):ResponseEntity<CertificateDocumentResponseDto>
+    fun setCertificateDocument(@RequestBody certificateDocumentRequestDto: CertificateDocumentRequestDto): ResponseEntity<CertificateDocumentResponseDto>
+
+
+    @Operation(
+        summary = "Request a specific certificate document for a given BPN.",
+        operationId = "retrieveCertificateDocument",
+        description = "This endpoint call to request a specific certificate document for a given BPN.",
+        responses = [
+            ApiResponse(responseCode = "200", description = "Document for the given id"),
+            ApiResponse(responseCode = "400", description = "Malformed URL", content = [Content()]),
+            ApiResponse(responseCode = "401", description = "Unauthorized", content = [Content()]),
+            ApiResponse(responseCode = "404", description = "Certificate Document ID not found", content = [Content()]),
+            ApiResponse(responseCode = "406", description = "Document not available", content = [Content()]),
+            ApiResponse(responseCode = "503", description = "Service not available", content = [Content()])
+        ]
+    )
+    @GetMapping("/certificate/document/{cdID}")
+    @GetExchange("/certificate/document/{cdID}")
+    fun getCertificateDocument(@Parameter(description = "Certificate document ID") @PathVariable cdID: UUID): ResponseEntity<CertificateDocumentResponseDto>
+
 
     @Operation(
         summary = "Get all certificates of a given BPN.",

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/controller/CertificateController.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/controller/CertificateController.kt
@@ -29,6 +29,7 @@ import org.eclipse.tractusx.bpdmcertificatemanagement.service.toPageRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RestController
 import java.net.URI
+import java.util.*
 
 @RestController
 class CertificateController(
@@ -38,8 +39,12 @@ class CertificateController(
     override fun setCertificateDocument(certificateDocumentRequestDto: CertificateDocumentRequestDto): ResponseEntity<CertificateDocumentResponseDto> {
         val result = certificateService.createCertificate(certificateDocumentRequestDto)
         return ResponseEntity
-            .created(URI.create("/certificate/${result?.registrationNumber}")) // Set the resource URI
+            .created(URI.create("/certificate/${result?.documentID}")) // Set the resource URI
             .body(result)
+    }
+
+    override fun getCertificateDocument(cdID: UUID): ResponseEntity<CertificateDocumentResponseDto> {
+        return certificateService.retrieveCertificate(cdID)
     }
 
     override fun getCertificatesByBpnPaginated(

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/controller/MetadataController.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/controller/MetadataController.kt
@@ -27,9 +27,10 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-public open class MetadataController(
+class MetadataController(
     val metadataService: MetadataService
 ): MetadataApi {
+
     override fun setCertificateType(certificateTypeDto: CertificateTypeDto): CertificateTypeDto {
         return metadataService.createCertificateType(certificateTypeDto)
     }

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/dto/DocumentDto.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/dto/DocumentDto.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.bpdmcertificatemanagement.dto
+
+data class DocumentDto(
+    var certificateDocument: String,
+    val certificateDocumentFormat: FileType
+)

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/dto/FileType.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/dto/FileType.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.bpdmcertificatemanagement.dto
+
+enum class FileType {
+    PDF,
+    PNG,
+    JPG
+}

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/dto/request/CertificateDocumentRequestDto.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/dto/request/CertificateDocumentRequestDto.kt
@@ -21,6 +21,7 @@ package org.eclipse.tractusx.bpdmcertificatemanagement.dto.request
 
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdmcertificatemanagement.dto.CertificateTypeDto
+import org.eclipse.tractusx.bpdmcertificatemanagement.dto.DocumentDto
 import org.eclipse.tractusx.bpdmcertificatemanagement.dto.EnclosedSiteDto
 import org.eclipse.tractusx.bpdmcertificatemanagement.dto.TrustLevelType
 import org.eclipse.tractusx.bpdmcertificatemanagement.dto.TrustValidatorDto
@@ -46,5 +47,6 @@ data class CertificateDocumentRequestDto(
     val trustLevel: TrustLevelType,
     val validator: TrustValidatorDto? = null,
     val uploader: String? = null,
+    val document: DocumentDto
 )
 

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/dto/response/CertificateDocumentResponseDto.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/dto/response/CertificateDocumentResponseDto.kt
@@ -21,12 +21,14 @@ package org.eclipse.tractusx.bpdmcertificatemanagement.dto.response
 
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdmcertificatemanagement.dto.CertificateTypeDto
+import org.eclipse.tractusx.bpdmcertificatemanagement.dto.DocumentDto
 import org.eclipse.tractusx.bpdmcertificatemanagement.dto.EnclosedSiteDto
 import org.eclipse.tractusx.bpdmcertificatemanagement.dto.TrustLevelType
 import org.eclipse.tractusx.bpdmcertificatemanagement.dto.TrustValidatorDto
 import org.eclipse.tractusx.bpdmcertificatemanagement.dto.openapidescription.CommonDescription
 import java.time.Instant
 import java.time.ZonedDateTime
+import java.util.*
 
 data class CertificateDocumentResponseDto(
 
@@ -42,6 +44,8 @@ data class CertificateDocumentResponseDto(
     val trustLevel: TrustLevelType,
     val validator: TrustValidatorDto? = null,
     val uploader: String? = null,
+    val documentID: UUID,
+    val document: DocumentDto,
 
     @get:Schema(description = CommonDescription.createdAt)
     val createdAt: Instant,

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/entity/CertificateDB.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/entity/CertificateDB.kt
@@ -22,6 +22,7 @@ package org.eclipse.tractusx.bpdmcertificatemanagement.entity
 import jakarta.persistence.*
 import org.eclipse.tractusx.bpdmcertificatemanagement.dto.TrustLevelType
 import java.time.ZonedDateTime
+import java.util.*
 
 @Entity
 @Table(
@@ -68,5 +69,12 @@ class CertificateDB(
 
     @Column(name = "uploader")
     var uploader: String?,
+
+    @Column(name = "document_id", unique = true)
+    val documentID: UUID = UUID.randomUUID(),
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
+    @JoinColumn(name = "document_file_id", unique = true)
+    var document: DocumentDB,
 
 ): BaseEntity()

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/entity/DocumentDB.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/entity/DocumentDB.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.bpdmcertificatemanagement.entity
+
+import jakarta.persistence.*
+import org.eclipse.tractusx.bpdmcertificatemanagement.dto.FileType
+
+@Entity
+@Table(name = "document")
+class DocumentDB (
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "certificate_sequence")
+    @SequenceGenerator(name = "certificate_sequence", sequenceName = "certificate_sequence", allocationSize = 1)
+    @Column(name = "id", nullable = false, updatable = false, insertable = false)
+    val id: Long = 0,
+
+    @Column(name = "certificate_file", nullable = false, columnDefinition = "TEXT")
+    var certificateDocument: String,
+
+    @Column(name = "certificate_format", nullable = false)
+    @Enumerated(EnumType.STRING)
+    val certificateDocumentFormat: FileType
+
+)

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/exception/CertificateControllerExceptionHandler.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/exception/CertificateControllerExceptionHandler.kt
@@ -85,5 +85,15 @@ class CertificateControllerExceptionHandler {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse)
     }
 
+    @ExceptionHandler(CertificateDocumentIdNotFound::class)
+    fun handleCertificateDocumentIdNotFound(ex: CertificateDocumentIdNotFound, request: WebRequest): ResponseEntity<CustomErrorResponse> {
+        val errorResponse = CustomErrorResponse(
+            timestamp = ZonedDateTime.now(),
+            status = HttpStatus.NOT_FOUND,
+            error = ex.message.toString(),
+            path = request.getDescription(false)
+        )
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse)
+    }
 
 }

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/exception/CertificateDocumentIdNotFound.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/exception/CertificateDocumentIdNotFound.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.bpdmcertificatemanagement.exception
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ResponseStatus
+
+@ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+class CertificateDocumentIdNotFound(
+    documentId: String
+):RuntimeException("Certificate with document ID ($documentId) doesn't exist")

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/repository/CertificateRepository.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/repository/CertificateRepository.kt
@@ -24,8 +24,10 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.CrudRepository
 import org.springframework.data.repository.PagingAndSortingRepository
+import java.util.*
 
 interface CertificateRepository: PagingAndSortingRepository<CertificateDB, Long>, CrudRepository<CertificateDB, Long> {
+
     fun findByBusinessPartnerNumber(key: String, pageable: Pageable): Page<CertificateDB>
 
     fun findByEnclosedSitesSiteBpn(siteBpn: String, pageable: Pageable): Page<CertificateDB>
@@ -33,5 +35,7 @@ interface CertificateRepository: PagingAndSortingRepository<CertificateDB, Long>
     fun findByBusinessPartnerNumberAndTypeCertificateType(bpn: String, certificateType: String, pageable: Pageable): Page<CertificateDB>
 
     fun findByEnclosedSitesSiteBpnAndTypeCertificateType(siteBpn: String, certificateType: String, pageable: Pageable): Page<CertificateDB>
+
+    fun findByDocumentID(id: UUID): CertificateDB?
 }
 

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/service/CertificateMapping.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/service/CertificateMapping.kt
@@ -20,15 +20,13 @@
 package org.eclipse.tractusx.bpdmcertificatemanagement.service
 
 import org.eclipse.tractusx.bpdmcertificatemanagement.dto.CertificateTypeDto
+import org.eclipse.tractusx.bpdmcertificatemanagement.dto.DocumentDto
 import org.eclipse.tractusx.bpdmcertificatemanagement.dto.EnclosedSiteDto
 import org.eclipse.tractusx.bpdmcertificatemanagement.dto.TrustValidatorDto
 import org.eclipse.tractusx.bpdmcertificatemanagement.dto.request.CertificateDocumentRequestDto
 import org.eclipse.tractusx.bpdmcertificatemanagement.dto.response.CertificateDocumentResponseDto
 import org.eclipse.tractusx.bpdmcertificatemanagement.dto.response.CertificateResponseDto
-import org.eclipse.tractusx.bpdmcertificatemanagement.entity.CertificateDB
-import org.eclipse.tractusx.bpdmcertificatemanagement.entity.CertificateTypeDB
-import org.eclipse.tractusx.bpdmcertificatemanagement.entity.EnclosedSiteDB
-import org.eclipse.tractusx.bpdmcertificatemanagement.entity.TrustValidatorDB
+import org.eclipse.tractusx.bpdmcertificatemanagement.entity.*
 import org.springframework.stereotype.Service
 import java.time.ZonedDateTime
 
@@ -48,15 +46,10 @@ class CertificateMapping {
             issuer = dto.issuer,
             trustLevel = dto.trustLevel,
             validator = dto.validator?.let { toTrustValidatorDB(it) },
-            uploader = dto.uploader
+            uploader = dto.uploader,
+            document = toDocumentDB(dto.document)
         )
     }
-
-    private fun toCertificateTypeDB(dto: CertificateTypeDto) =
-        CertificateTypeDB(
-            certificateType = dto.certificateType,
-            certificateVersion = dto.certificateVersion
-        )
 
     private fun toEnclosedSitesDB(dto: EnclosedSiteDto) =
         EnclosedSiteDB(
@@ -73,6 +66,12 @@ class CertificateMapping {
         }
     }
 
+    private fun toDocumentDB(dto: DocumentDto) =
+        DocumentDB(
+            certificateDocument = dto.certificateDocument,
+            certificateDocumentFormat = dto.certificateDocumentFormat,
+        )
+
     fun toCertificateDocumentResponseDto(entity: CertificateDB): CertificateDocumentResponseDto {
         return CertificateDocumentResponseDto(
             businessPartnerNumber = entity.businessPartnerNumber,
@@ -87,6 +86,8 @@ class CertificateMapping {
             trustLevel = entity.trustLevel,
             validator = entity.validator?.let { toTrustValidatorDto(it) },
             uploader = entity.uploader,
+            documentID = entity.documentID,
+            document = toDocumentDto(entity.document),
             createdAt = entity.createdAt,
             updatedAt = entity.updatedAt
         )
@@ -142,5 +143,11 @@ class CertificateMapping {
             return ZonedDateTime.now()
         return dateTime
     }
+
+    private fun toDocumentDto(entity: DocumentDB): DocumentDto =
+        DocumentDto(
+            certificateDocument = entity.certificateDocument,
+            certificateDocumentFormat = entity.certificateDocumentFormat,
+        )
 
 }

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/service/CertificateService.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/service/CertificateService.kt
@@ -26,14 +26,16 @@ import org.eclipse.tractusx.bpdmcertificatemanagement.dto.response.CertificateDo
 import org.eclipse.tractusx.bpdmcertificatemanagement.dto.response.CertificateResponseDto
 import org.eclipse.tractusx.bpdmcertificatemanagement.dto.response.PageDto
 import org.eclipse.tractusx.bpdmcertificatemanagement.entity.CertificateTypeDB
+import org.eclipse.tractusx.bpdmcertificatemanagement.exception.CertificateDocumentIdNotFound
 import org.eclipse.tractusx.bpdmcertificatemanagement.exception.CertificateNotExists
 import org.eclipse.tractusx.bpdmcertificatemanagement.exception.CertificateTypeNotExists
 import org.eclipse.tractusx.bpdmcertificatemanagement.exception.InvalidBpnFormatException
 import org.eclipse.tractusx.bpdmcertificatemanagement.repository.CertificateRepository
 import org.eclipse.tractusx.bpdmcertificatemanagement.repository.CertificateTypeRepository
 import org.springframework.data.domain.PageRequest
+import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
-import java.lang.IllegalArgumentException
+import java.util.*
 
 @Service
 class CertificateService(
@@ -54,6 +56,17 @@ class CertificateService(
         val result = certificateRepository.save(entity)
 
         return certificateMapping.toCertificateDocumentResponseDto(result)
+
+    }
+
+
+    fun retrieveCertificate(cdID: UUID): ResponseEntity<CertificateDocumentResponseDto> {
+        logger.debug { "Executing retrieveCertificate() with parameters $cdID" }
+
+        val certificate = certificateRepository.findByDocumentID(cdID)
+            ?: throw CertificateDocumentIdNotFound(cdID.toString())
+
+        return ResponseEntity.ok(certificateMapping.toCertificateDocumentResponseDto(certificate))
 
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -37,3 +37,4 @@ spring.datasource.driverClassName=org.postgresql.Driver
 spring.datasource.username=bpdm_certificates
 spring.datasource.password=
 spring.jpa.hibernate.ddl-auto=update
+


### PR DESCRIPTION
## Description

This PR adds two different endpoints for retrieving and inserting a document in Base64 format and with the relevant type (PDF, PNG or JPG).

Contributes to #4 and #5 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
