### PR TITLE
feat(bpdm-cert): validation added for certificate and type creation

### DIFF
--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/dto/TrustLevelType.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/dto/TrustLevelType.kt
@@ -17,13 +17,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.eclipse.tractusx.bpdmcertificatemanagement.exception
+package org.eclipse.tractusx.bpdmcertificatemanagement.dto
 
-import org.springframework.http.HttpStatus
-import org.springframework.web.bind.annotation.ResponseStatus
-
-@ResponseStatus(HttpStatus.CONFLICT)
-class CertificateAlreadyExists(
-    objectType: String,
-    identifier: String
-): RuntimeException("$objectType with the following identifier already exists: $identifier")
+enum class TrustLevelType {
+    None,
+    Low,
+    Medium,
+    High,
+    Trusted
+}

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/dto/request/CertificateDocumentRequestDto.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/dto/request/CertificateDocumentRequestDto.kt
@@ -22,6 +22,7 @@ package org.eclipse.tractusx.bpdmcertificatemanagement.dto.request
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdmcertificatemanagement.dto.CertificateTypeDto
 import org.eclipse.tractusx.bpdmcertificatemanagement.dto.EnclosedSiteDto
+import org.eclipse.tractusx.bpdmcertificatemanagement.dto.TrustLevelType
 import org.eclipse.tractusx.bpdmcertificatemanagement.dto.TrustValidatorDto
 import org.eclipse.tractusx.bpdmcertificatemanagement.dto.openapidescription.CommonDescription
 import java.time.ZonedDateTime
@@ -32,7 +33,7 @@ import java.time.ZonedDateTime
 )
 data class CertificateDocumentRequestDto(
 
-    val businessPartnerNumber: String? = null,
+    val businessPartnerNumber: String,
     @get:Schema(description = CommonDescription.type)
     val type: CertificateTypeDto,
     val registrationNumber: String? = null,
@@ -42,7 +43,7 @@ data class CertificateDocumentRequestDto(
     val validFrom: ZonedDateTime? = null,
     val validUntil: ZonedDateTime? = null,
     val issuer: String? = null,
-    val trustLevel: String? = null,
+    val trustLevel: TrustLevelType,
     val validator: TrustValidatorDto? = null,
     val uploader: String? = null,
 )

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/dto/response/CertificateDocumentResponseDto.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/dto/response/CertificateDocumentResponseDto.kt
@@ -22,10 +22,10 @@ package org.eclipse.tractusx.bpdmcertificatemanagement.dto.response
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdmcertificatemanagement.dto.CertificateTypeDto
 import org.eclipse.tractusx.bpdmcertificatemanagement.dto.EnclosedSiteDto
+import org.eclipse.tractusx.bpdmcertificatemanagement.dto.TrustLevelType
 import org.eclipse.tractusx.bpdmcertificatemanagement.dto.TrustValidatorDto
 import org.eclipse.tractusx.bpdmcertificatemanagement.dto.openapidescription.CommonDescription
 import java.time.Instant
-import java.time.LocalDateTime
 import java.time.ZonedDateTime
 
 data class CertificateDocumentResponseDto(
@@ -39,7 +39,7 @@ data class CertificateDocumentResponseDto(
     val validFrom: ZonedDateTime? = null,
     val validUntil: ZonedDateTime? = null,
     val issuer: String? = null,
-    val trustLevel: String? = null,
+    val trustLevel: TrustLevelType,
     val validator: TrustValidatorDto? = null,
     val uploader: String? = null,
 

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/dto/response/CertificateResponseDto.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/dto/response/CertificateResponseDto.kt
@@ -22,6 +22,7 @@ package org.eclipse.tractusx.bpdmcertificatemanagement.dto.response
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdmcertificatemanagement.dto.CertificateTypeDto
 import org.eclipse.tractusx.bpdmcertificatemanagement.dto.EnclosedSiteDto
+import org.eclipse.tractusx.bpdmcertificatemanagement.dto.TrustLevelType
 import org.eclipse.tractusx.bpdmcertificatemanagement.dto.TrustValidatorDto
 import org.eclipse.tractusx.bpdmcertificatemanagement.dto.openapidescription.CommonDescription
 import java.time.Instant
@@ -37,7 +38,7 @@ data class CertificateResponseDto(
     val validFrom: ZonedDateTime? = null,
     val validUntil: ZonedDateTime? = null,
     val issuer: String? = null,
-    val trustLevel: String? = null,
+    val trustLevel: TrustLevelType,
     val validator: TrustValidatorDto? = null,
     val uploader: String? = null,
 

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/entity/CertificateDB.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/entity/CertificateDB.kt
@@ -20,6 +20,7 @@
 package org.eclipse.tractusx.bpdmcertificatemanagement.entity
 
 import jakarta.persistence.*
+import org.eclipse.tractusx.bpdmcertificatemanagement.dto.TrustLevelType
 import java.time.ZonedDateTime
 
 @Entity
@@ -58,8 +59,9 @@ class CertificateDB(
     @Column(name = "issuer")
     var issuer: String?,
 
-    @Column(name = "trust_level")
-    var trustLevel: String?,
+    @Column(name = "trust_level", nullable = false)
+    @Enumerated(EnumType.STRING)
+    var trustLevel: TrustLevelType,
 
     @Embedded
     var validator: TrustValidatorDB?,

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/exception/CertificateControllerExceptionHandler.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/exception/CertificateControllerExceptionHandler.kt
@@ -24,41 +24,66 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.context.request.WebRequest
 import java.time.ZonedDateTime
 
 @ControllerAdvice
 class CertificateControllerExceptionHandler {
 
     @ExceptionHandler(CertificateTypeNotExists::class)
-    fun handleCertificateTypeNotExists(ex: CertificateTypeNotExists): ResponseEntity<CustomErrorResponse> {
+    fun handleCertificateTypeNotExists(ex: CertificateTypeNotExists, request: WebRequest): ResponseEntity<CustomErrorResponse> {
         val errorResponse = CustomErrorResponse(
             timestamp = ZonedDateTime.now(),
             status = HttpStatus.UNPROCESSABLE_ENTITY,
             error = ex.message.toString(),
-            path = "/api/catena/certificate/document"
+            path = request.getDescription(false)
         )
         return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(errorResponse)
     }
 
     @ExceptionHandler(InvalidBpnFormatException::class)
-    fun handleBusinessPartnerDetails(ex: InvalidBpnFormatException): ResponseEntity<CustomErrorResponse> {
+    fun handleBusinessPartnerDetails(ex: InvalidBpnFormatException, request: WebRequest): ResponseEntity<CustomErrorResponse> {
         val errorResponse = CustomErrorResponse(
             timestamp = ZonedDateTime.now(),
             status = HttpStatus.BAD_REQUEST,
             error = ex.message.toString(),
-            path = "/api/catena/certificate/{bpn}"
+            path = request.getDescription(false)
         )
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse)
     }
 
     @ExceptionHandler(CertificateNotExists::class)
-    fun handleCertificateNotExists(ex: CertificateNotExists): ResponseEntity<CustomErrorResponse> {
+    fun handleCertificateNotExists(ex: CertificateNotExists, request: WebRequest): ResponseEntity<CustomErrorResponse> {
         val errorResponse = CustomErrorResponse(
             timestamp = ZonedDateTime.now(),
             status = HttpStatus.NOT_FOUND,
             error = ex.message.toString(),
-            path = "/api/catena/certificate/{bpn}"
+            path = request.getDescription(false)
         )
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse)
     }
+
+    @ExceptionHandler(InvalidTypeFormatException::class)
+    fun handleInvalidTypeException(ex: InvalidTypeFormatException, request: WebRequest): ResponseEntity<CustomErrorResponse> {
+        val errorResponse = CustomErrorResponse(
+            timestamp = ZonedDateTime.now(),
+            status = HttpStatus.BAD_REQUEST,
+            error = ex.message.toString(),
+            path = request.getDescription(false)
+        )
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse)
+    }
+
+    @ExceptionHandler(CertificateTypeAlreadyExists::class)
+    fun handleCertificateTypeAlreadyExists(ex: CertificateTypeAlreadyExists, request: WebRequest): ResponseEntity<CustomErrorResponse> {
+        val errorResponse = CustomErrorResponse(
+            timestamp = ZonedDateTime.now(),
+            status = HttpStatus.CONFLICT,
+            error = ex.message.toString(),
+            path = request.getDescription(false)
+        )
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse)
+    }
+
+
 }

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/exception/CertificateTypeAlreadyExists.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/exception/CertificateTypeAlreadyExists.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.bpdmcertificatemanagement.exception
+
+class CertificateTypeAlreadyExists(
+    objectType: String,
+    identifier: String
+): RuntimeException("$objectType with the following identifier already exists: $identifier")

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/exception/InvalidTypeFormatException.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/exception/InvalidTypeFormatException.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.bpdmcertificatemanagement.exception
+
+class InvalidTypeFormatException(
+    certificateType: String,
+    certificateVersion: String
+): RuntimeException("The type is not valid with provided $certificateType and $certificateVersion")

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/service/CertificateMapping.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/service/CertificateMapping.kt
@@ -30,6 +30,7 @@ import org.eclipse.tractusx.bpdmcertificatemanagement.entity.CertificateTypeDB
 import org.eclipse.tractusx.bpdmcertificatemanagement.entity.EnclosedSiteDB
 import org.eclipse.tractusx.bpdmcertificatemanagement.entity.TrustValidatorDB
 import org.springframework.stereotype.Service
+import java.time.ZonedDateTime
 
 @Service
 class CertificateMapping {
@@ -42,8 +43,8 @@ class CertificateMapping {
             areaOfApplication = dto.areaOfApplication,
             remark = dto.remark,
             enclosedSites = dto.enclosedSites?.mapNotNull { toEnclosedSitesDB(it) }?.toSortedSet(),
-            validFrom = dto.validFrom,
-            validUntil = dto.validUntil,
+            validFrom = toDefaultMappingValidFrom(dto.validFrom),
+            validUntil = toDefaultMappingValidUntil(dto.validUntil),
             issuer = dto.issuer,
             trustLevel = dto.trustLevel,
             validator = dto.validator?.let { toTrustValidatorDB(it) },
@@ -128,6 +129,18 @@ class CertificateMapping {
             validatorName = entity.validatorName,
             validatorBpn = entity.validatorBpn
         )
+    }
+
+    private fun toDefaultMappingValidUntil(dateTime: ZonedDateTime?):ZonedDateTime{
+        if (dateTime == null)
+            return ZonedDateTime.parse("9999-12-31T23:59:59Z")
+        return dateTime
+    }
+
+    private fun toDefaultMappingValidFrom(dateTime: ZonedDateTime?):ZonedDateTime{
+        if (dateTime == null)
+            return ZonedDateTime.now()
+        return dateTime
     }
 
 }


### PR DESCRIPTION
## Description
In this pull request, added validation for certificate creation as well as for creating metadata. Validation mainly based on attribute level where some either default value assigned or thrown the exception so user can easily get it. Also, added enum for trustLevel.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
