### PR TITLE
feat(bpdm-cert): updated application version with enabling feature of…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>org.eclipse.tractusx</groupId>
     <artifactId>bpdm-certificate-management</artifactId>
-    <version>0.0.3-SNAPSHOT</version>
+    <version>0.0.4-SNAPSHOT</version>
     <name>bpdm-certificate-management</name>
     <description>bpdm-certificate-management</description>
 

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/config/OpenApiConfiguration.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/config/OpenApiConfiguration.kt
@@ -22,8 +22,7 @@ package org.eclipse.tractusx.bpdmcertificatemanagement.config
 import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
-import io.swagger.v3.oas.models.security.SecurityRequirement
-import io.swagger.v3.oas.models.security.SecurityScheme
+import io.swagger.v3.oas.models.security.*
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -42,19 +41,19 @@ class OpenApiConfiguration (
     private fun OpenAPI.withSecurity(): OpenAPI {
         return this.components(
             Components()
-//                .addSecuritySchemes(
-//                    "open_id_scheme",
-//                    SecurityScheme().type(SecurityScheme.Type.OAUTH2).flows(
-//                        OAuthFlows().authorizationCode(
-//                            OAuthFlow().authorizationUrl(securityProperties.authUrl)
-//                                .tokenUrl(securityProperties.tokenUrl)
-//                                .refreshUrl(securityProperties.refreshUrl)
-//                                .scopes(Scopes())
-//                        ).clientCredentials(
-//                            OAuthFlow().tokenUrl(securityProperties.tokenUrl)
-//                        )
-//                    )
-//                )
+                .addSecuritySchemes(
+                    "open_id_scheme",
+                    SecurityScheme().type(SecurityScheme.Type.OAUTH2).flows(
+                        OAuthFlows().authorizationCode(
+                            OAuthFlow().authorizationUrl(securityProperties.authUrl)
+                                .tokenUrl(securityProperties.tokenUrl)
+                                .refreshUrl(securityProperties.refreshUrl)
+                                .scopes(Scopes())
+                        ).clientCredentials(
+                            OAuthFlow().tokenUrl(securityProperties.tokenUrl)
+                        )
+                    )
+                )
                 .addSecuritySchemes(
                     "bearer_scheme",
                     SecurityScheme().type(SecurityScheme.Type.HTTP)
@@ -62,7 +61,7 @@ class OpenApiConfiguration (
                         .bearerFormat("JWT")
                 )
         )
-            //.addSecurityItem(SecurityRequirement().addList("open_id_scheme", emptyList()))
+            .addSecurityItem(SecurityRequirement().addList("open_id_scheme", emptyList()))
             .addSecurityItem(SecurityRequirement().addList("bearer_scheme", emptyList()))
     }
 

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/controller/MetadataApi.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/controller/MetadataApi.kt
@@ -62,7 +62,7 @@ interface MetadataApi {
         description = "Get a list of all currently registered certificate types.",
         responses = [
             ApiResponse(responseCode = "200", description = "List of registered certificate types, or can be empty"),
-            ApiResponse(responseCode = "400", description = "Malformed URL")
+            ApiResponse(responseCode = "400", description = "Malformed URL", content = [Content()])
         ]
     )
     @GetMapping("/certificate-types")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,7 +24,8 @@ bpdm-cert:
     name: "BPDM Certificate Management"
     description: "Service that manages and shares business partner certificates"
     version: "0.0.1"
-
+    datasource:
+        host: localhost
     security:
         enabled: false
 
@@ -43,7 +44,7 @@ spring:
     datasource:
         driverClassName: org.postgresql.Driver
         password: ''
-        url: jdbc:postgresql://localhost:5432/bpdm_certificates
+        url: jdbc:postgresql://${bpdm-cert.datasource.host}:5432/bpdm_certificates
         username: bpdm_certificates
     # Flyway configuration
     flyway:


### PR DESCRIPTION
## Description
In this pull request, updated application version along with the open id scheme enabled for authentication.
Also, fixed response related to GET endpoint on metadata controller.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
