### PR TITLE
Helm chart deployment with Postgres database enabled and added ingress and auth support

### DIFF
--- a/charts/bpdm-certificate-management/templates/_helpers.tpl
+++ b/charts/bpdm-certificate-management/templates/_helpers.tpl
@@ -75,3 +75,20 @@ Create name of application secret
 {{- printf "%s-application" (include "bpdm-certificate-management.fullname" .) }}
 {{- end }}
 
+{/*
+Determine postgres service/host name to connect to
+*/}}
+{{- define "bpdm-certificate-management.postgresDependency" -}}
+        {{- include "includeWithPostgresContext" (list $ "postgresql.primary.fullname") }}
+{{- end }}}
+
+
+{{/*
+Invoke include on given definition with postgresql dependency context
+Usage: include "includeWithPostgresContext" (list $ "your_include_function_here")
+*/}}
+{{- define "includeWithPostgresContext" -}}
+{{- $ := index . 0 }}
+{{- $function := index . 1 }}
+{{- include $function (dict "Values" $.Values.postgres "Chart" (dict "Name" "postgres") "Release" $.Release) }}
+{{- end }}

--- a/charts/bpdm-certificate-management/templates/configMap.yaml
+++ b/charts/bpdm-certificate-management/templates/configMap.yaml
@@ -18,20 +18,21 @@
 # SPDX-License-Identifier: Apache-2.0
 ################################################################################
 
-apiVersion: v2
-type: application
-name: bpdm-certificate-management
-appVersion: "0.0.4"
-version: 0.0.1-alpha.2
-description: A Helm chart for deploying the BPDM Certificate Management application
-sources:
-  - https://github.com/eclipse-tractusx/bpdm-certificate-management
-dependencies:
-  - name: postgresql
-    version: 11.9.13
-    repository: https://charts.bitnami.com/bitnami
-    alias: postgres
-    condition: postgres.enabled
-maintainers:
-  - name: Sujit Karne
-  - name: Nico Koprowski
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{include "bpdm-certificate-management.fullname" .}}
+  labels:
+    {{- include "bpdm-certificate-management.labels" . | nindent 4 }}
+data:
+  deployment.yml: |-
+    # Place for putting standard deployment configuration
+    # which can be overwritten by external.yml
+    bpdm-cert:
+      datasource:
+        host: {{ include "bpdm-certificate-management.postgresDependency" . }}
+  external.yml: |-
+    # External properties for overwriting application config
+    {{- if .Values.applicationConfig }}
+    {{- .Values.applicationConfig | toYaml | nindent 4 }}
+    {{- end }}

--- a/charts/bpdm-certificate-management/templates/deployment.yaml
+++ b/charts/bpdm-certificate-management/templates/deployment.yaml
@@ -33,9 +33,10 @@ spec:
       {{- include "bpdm-certificate-management.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+        checksum/config: {{ include (print $.Template.BasePath "/configMap.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
+      {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
         {{- include "bpdm-certificate-management.selectorLabels" . | nindent 8 }}
@@ -52,11 +53,23 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: {{ .Values.springProfiles | join "," }}
+            - name: BPDM-CERT_DATASOURCE_HOST
+              value: {{ include "bpdm-certificate-management.postgresDependency" . }}
+            - name: SPRING_CONFIG_IMPORT
+              value: "/etc/conf/deployment.yml,/etc/conf/external.yml,/etc/conf/secrets.yml"
+            - name: SPRING_DATASOURCE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "bpdm-certificate-management.postgresDependency" . }}
+                  key: password
           ports:
             - name: http
-              containerPort: 8084
+              containerPort: 8086
               protocol: TCP
           # @url: https://cloud.google.com/blog/products/containers-kubernetes/kubernetes-best-practices-setting-up-health-checks-with-readiness-and-liveness-probes
           livenessProbe:
@@ -67,6 +80,10 @@ spec:
             {{- toYaml .Values.startupProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /etc/conf
+              name: config
+              readOnly: true
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -79,3 +96,11 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      volumes:
+        - name: config
+          projected:
+            sources:
+              - configMap:
+                  name: {{ include "bpdm-certificate-management.fullname" . }}
+              - secret:
+                  name: {{ include "bpdm-certificate-management.fullname" . }}

--- a/charts/bpdm-certificate-management/templates/ingress.yaml
+++ b/charts/bpdm-certificate-management/templates/ingress.yaml
@@ -1,0 +1,62 @@
+{{ if .Values.ingress.enabled }}
+
+{{- $fullName := include "bpdm-certificate-management.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "bpdm-certificate-management.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/bpdm-certificate-management/values.yaml
+++ b/charts/bpdm-certificate-management/values.yaml
@@ -38,8 +38,6 @@ podAnnotations: {}
 springProfiles: []
 
 securityContext:
-  seccompProfile:
-    type: RuntimeDefault
   allowPrivilegeEscalation: false
   runAsNonRoot: true
   runAsUser: 10001
@@ -50,11 +48,17 @@ securityContext:
 
 service:
   type: ClusterIP
-  port: 8080
+  port: 8086
   targetPort: 8086
 
 autoscaling:
   enabled: false
+
+ingress:
+  enabled: false
+  annotations: {}
+  hosts: []
+  tls: []
 
 resources:
   limits:
@@ -107,3 +111,21 @@ startupProbe:
   initialDelaySeconds: 60
   failureThreshold: 20
   periodSeconds: 15
+
+# Used to overwrite the default property values of the application configuration
+applicationConfig:
+#  spring:
+#    datasource:
+#      url: jdbc:postgresql://release-bpdm-cert-postgres:5432/bpdm_certificates
+
+configmap:
+  create: true
+
+# Used to overwrite the secret property values of the application configuration
+applicationSecrets:
+
+postgres:
+  enabled: true
+  auth:
+    database: bpdm_certificates
+    username: bpdm_certificates


### PR DESCRIPTION
## Description
In this pull request, we are upgrading helm chart with Postgres database also added ingress and auth support.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
