### PR TITLE
feat(bpdm-cert): created workflow for publishing swagger hub api

### DIFF
--- a/.github/workflows/publish-swagger-hub.yaml
+++ b/.github/workflows/publish-swagger-hub.yaml
@@ -1,0 +1,117 @@
+################################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
+
+name: "Publish OpenAPI to Swaggerhub"
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*.*.*'
+      - 'v*.*.*-*'
+  workflow_call:
+    inputs:
+      version:
+        required: false
+        default: 'main'
+        type: string
+
+  workflow_dispatch:
+    inputs:
+      version:
+        required: false
+        description: "Version of the BPDM Certificate Management API is to be published"
+        default: 'main'
+        type: string
+
+jobs:
+  swagger-api:
+    runs-on: ubuntu-latest
+    env:
+      SWAGGERHUB_API_KEY: ${{ secrets.SWAGGERHUB_API_KEY }}
+      SWAGGERHUB_USER: ${{ secrets.SWAGGERHUB_USER }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+
+      - name: Install Swagger CLI
+        run: |
+          npm i -g swaggerhub-cli
+
+      - name: Extract versions
+        run: |
+          if [ -z "${{ inputs.downstream-version }}" ]; then
+            export DOWNSTREAM_VERSION=$(grep -A1 '<artifactId>bpdm-certificate-management</artifactId>' pom.xml | grep '<version>' | awk -F '>' '{print $2}' | awk -F '<' '{print $1}')
+          else
+            export DOWNSTREAM_VERSION="${{ inputs.downstream-version }}"
+          fi
+
+          echo "DOWNSTREAM_VERSION=${DOWNSTREAM_VERSION}" >> "$GITHUB_ENV"
+
+      - name: Create and Download API specs
+        shell: bash
+        run: |
+          echo "[INFO] - Create the docker network"
+          docker network create bpdm-network
+          echo "[INFO] - Compiling the project"
+          mvn -B clean install -DskipTests
+          echo "[INFO] - Building a docker image - bpdm-certificate-management:test"
+          docker build -f docker/Dockerfile . --tag bpdm-certificate-management:test
+          echo "[INFO] - Starting a docker container for bpdm-certificate-postgres database"
+          docker run -d --name bpdm-certificate-postgres --network bpdm-network -e POSTGRES_USER=bpdm_certificates -e POSTGRES_PASSWORD= -e POSTGRES_DB=bpdm_certificates -e POSTGRES_HOST_AUTH_METHOD=trust -p 5432:5432 -v bpdm-certificate-postgres-data:/var/lib/postgresql/data postgres:14.2
+          echo "[INFO] - Wait for some seconds until the docker container comes up"
+          sleep 20
+          echo "[INFO] - Starting a docker container to download API specs - bpdm-certificate-management"
+          docker run -d --name bpdm-certificate-management --network bpdm-network -e SPRING_DATASOURCE_PASSWORD= -e BPDM-CERT_DATASOURCE_HOST=bpdm-certificate-postgres -p 8086:8086 bpdm-certificate-management:test
+          echo "[INFO] - Wait for some seconds until the docker container comes up"
+          sleep 20
+          curl -X GET http://localhost:8086/docs/api-docs.yaml > ./tractusx-bpdm-certificate-api.yaml
+          echo "[INFO] - Stopping and removing docker container"
+          docker stop bpdm-certificate-management
+          docker stop bpdm-certificate-postgres
+          docker rm bpdm-certificate-management
+          docker rm bpdm-certificate-postgres
+          docker network rm bpdm-network
+
+      # create API, will fail if exists
+      - name: Create API
+        continue-on-error: true
+        run: |
+          swaggerhub api:create ${{ env.SWAGGERHUB_USER }}/bpdm-certificate-management/${{ env.DOWNSTREAM_VERSION }} -f ./tractusx-bpdm-certificate-api.yaml --visibility=public --published=unpublish
+
+      # Post the API to SwaggerHub as "unpublished", because published APIs cannot be overwritten
+      - name: Publish API Specs to SwaggerHub
+        run: |
+          if [[ ${{ env.DOWNSTREAM_VERSION }} != *-SNAPSHOT ]]; then
+            echo "[INFO] - no snapshot, will set the API to 'published'";
+            swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/bpdm-certificate-management/${{ env.DOWNSTREAM_VERSION }} -f ./tractusx-bpdm-certificate-api.yaml --visibility=public --published=publish
+            swaggerhub api:setdefault ${{ env.SWAGGERHUB_USER }}/bpdm-certificate-management/${{ env.DOWNSTREAM_VERSION }}
+          else
+            echo "[INFO] - snapshot, will set the API to 'unpublished'";
+            swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/bpdm-certificate-management/${{ env.DOWNSTREAM_VERSION }} -f ./tractusx-bpdm-certificate-api.yaml --visibility=public --published=unpublish
+          fi


### PR DESCRIPTION
## Description

In this pull request, we are creating gitHub workflow for creating/updating swagger hub apis regarding bpdm certificate management application.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
