### PR TITLE
feat(bpdm-certificate-management): KICS Workflow Addition

### DIFF
--- a/.github/workflows/kics.yaml
+++ b/.github/workflows/kics.yaml
@@ -1,0 +1,68 @@
+---
+################################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
+
+name: "KICS"
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: KICS scan
+        uses: checkmarx/kics-github-action@master
+        with:
+          # Scanning directory .
+          path: "./charts"
+          # Exclude paths from scan by providing the paths as comma separated list
+          # exclude_paths: "postgres-init.yaml,templates/sharedidp.yaml"
+          # Exclude queries by providing the query / rule ID as comma separated list
+          # exclude_queries: "b9c83569-459b-4110-8f79-6305aa33cb37"
+          # Fail on HIGH severity results
+          fail_on: high
+          # Disable secrets detection - we use GitGuardian
+          disable_secrets: true
+          # When provided with a directory on output_path
+          # it will generate the specified reports file named 'results.{extension}'
+          # in this example it will generate:
+          # - results-dir/results.json and results-dir/results.sarif
+          output_path: kicsResults/
+          output_formats: "json,sarif"
+
+      # Upload findings to GitHub Advanced Security Dashboard
+      - name: Upload SARIF file for GitHub Advanced Security Dashboard
+        if: always()
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: kicsResults/results.sarif


### PR DESCRIPTION
## Description

Adds KICKS in GitHub workflows.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
