### PR TITLE
feat(bpdm-certificate-management): Helm chart 1.0.0 for app version 1…

### DIFF
--- a/charts/bpdm-certificate-management/CHANGELOG.md
+++ b/charts/bpdm-certificate-management/CHANGELOG.md
@@ -3,3 +3,10 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
+
+## [1.0.0] - Unreleased
+
+### Added
+
+- Helm Charts for BPDM Certificate Management Application
+- Onboarding new BPDM-Certificate-Application 

--- a/charts/bpdm-certificate-management/Chart.yaml
+++ b/charts/bpdm-certificate-management/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-certificate-management
-appVersion: "0.0.4"
-version: 0.0.1-alpha.2
+appVersion: "1.0.0"
+version: 1.0.0
 description: A Helm chart for deploying the BPDM Certificate Management application
 sources:
   - https://github.com/eclipse-tractusx/bpdm-certificate-management


### PR DESCRIPTION
## Description
In this pull request, creating stable chart version for bpdm certificate management application.
where application version is 1.0.0

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
