### PR TITLE
fix(bpdm-certificate-management): Validation for BPN for site and address

### DIFF
--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/exception/CertificateControllerExceptionHandler.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/exception/CertificateControllerExceptionHandler.kt
@@ -109,4 +109,14 @@ class CertificateControllerExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse)
     }
 
+    @ExceptionHandler(InvalidSiteFormatException::class)
+    fun handleInvalidSiteOrAddressBpnFormat(ex: InvalidSiteFormatException, request: WebRequest): ResponseEntity<CustomErrorResponse> {
+        val errorResponse = CustomErrorResponse(
+            timestamp = ZonedDateTime.now(),
+            status = HttpStatus.BAD_REQUEST,
+            error = ex.message.toString(),
+            path = request.getDescription(false)
+        )
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse)
+    }
 }

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/exception/InvalidSiteFormatException.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/exception/InvalidSiteFormatException.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.bpdmcertificatemanagement.exception
+
+class InvalidSiteFormatException (
+    bpn: String
+): RuntimeException("The bpn value $bpn is not a valid business partner number of Address. " +
+        "Format should follow the following example: BPNS12345678ABCD")

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/service/CertificateService.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/service/CertificateService.kt
@@ -30,6 +30,7 @@ import org.eclipse.tractusx.bpdmcertificatemanagement.entity.CertificateDB
 import org.eclipse.tractusx.bpdmcertificatemanagement.entity.CertificateTypeDB
 import org.eclipse.tractusx.bpdmcertificatemanagement.exception.*
 import org.eclipse.tractusx.bpdmcertificatemanagement.repository.CertificateRepository
+import org.eclipse.tractusx.bpdmcertificatemanagement.exception.*
 import org.eclipse.tractusx.bpdmcertificatemanagement.repository.CertificateTypeRepository
 import org.springframework.data.domain.PageRequest
 import org.springframework.http.ResponseEntity
@@ -189,6 +190,13 @@ class CertificateService(
         certificateDocumentRequestDto.issuer?.let { validateBPNLFormat (it) }
         certificateDocumentRequestDto.uploader?.let { validateBPNLFormat (it) }
         certificateDocumentRequestDto.validator?.validatorBpn?.let {  validateBPNLFormat (it)}
+
+        certificateDocumentRequestDto.enclosedSites?.forEach { enclosed ->
+            if (enclosed.siteBpn.length != 16 || !enclosed.siteBpn.startsWith("BPNS") || !enclosed.siteBpn.substring(4, 12).all { it.isDigit() } ||
+                !enclosed.siteBpn.substring(12).all { it.isLetterOrDigit() }) {
+                throw InvalidSiteFormatException(enclosed.siteBpn)
+            }
+        }
 
     }
 


### PR DESCRIPTION
## Description

In this PR, it was added an validation for business partner number for site and address in the SiteBpn field found in the enclosedSites.

Related to issue #65 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
