### PR TITLE
fix(bpdm-certificate-management): Small fix for Disabled Spring CSRF

### DIFF
--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/config/SecurityConfigurerAdapter.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/config/SecurityConfigurerAdapter.kt
@@ -31,7 +31,6 @@ class SecurityConfigurerAdapter(
 ) {
 
     fun configure(http: HttpSecurity) {
-        http.csrf { it.disable() }
         http.cors {}
         http.sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
         http.authorizeHttpRequests {


### PR DESCRIPTION
## Description

This PR removes code snippet that disabled CSRF protection. 

## Pre-review code snippet checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
