### PR TITLE
Feat(bpdm-certificate-management): Status Attribute and Logic

### DIFF
--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/dto/StatusType.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/dto/StatusType.kt
@@ -16,16 +16,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.eclipse.tractusx.bpdmcertificatemanagement
 
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.runApplication
-import org.springframework.scheduling.annotation.EnableScheduling
+package org.eclipse.tractusx.bpdmcertificatemanagement.dto
 
-@SpringBootApplication
-@EnableScheduling
-class Application
-
-fun main(args: Array<String>) {
-    runApplication<Application>(*args)
+enum class StatusType {
+    Active,
+    Inactive,
+    Pending,
+    NoTypeAssigned
 }

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/dto/response/CertificateDocumentResponseDto.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/dto/response/CertificateDocumentResponseDto.kt
@@ -42,6 +42,7 @@ data class CertificateDocumentResponseDto(
     val uploader: String? = null,
     val documentID: UUID,
     val document: DocumentDto,
+    val status: StatusType,
 
     @get:Schema(description = CommonDescription.createdAt)
     val createdAt: Instant,

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/entity/CertificateDB.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/entity/CertificateDB.kt
@@ -20,6 +20,7 @@
 package org.eclipse.tractusx.bpdmcertificatemanagement.entity
 
 import jakarta.persistence.*
+import org.eclipse.tractusx.bpdmcertificatemanagement.dto.StatusType
 import org.eclipse.tractusx.bpdmcertificatemanagement.dto.TrustLevelType
 import java.time.ZonedDateTime
 import java.util.*
@@ -57,6 +58,10 @@ class CertificateDB(
     @Column(name = "valid_until")
     var validUntil: ZonedDateTime?,
 
+    @Column(name = "status")
+    @Enumerated(EnumType.STRING)
+    var status: StatusType,
+
     @Column(name = "issuer")
     var issuer: String?,
 
@@ -77,4 +82,4 @@ class CertificateDB(
     @JoinColumn(name = "document_file_id", unique = true)
     var document: DocumentDB,
 
-): BaseEntity()
+    ): BaseEntity()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,8 @@ bpdm-cert:
         host: localhost
     security:
         enabled: false
+    task:
+        status-checker: 0 0 0 * * ?
 
 management:
     endpoint:

--- a/src/main/resources/db/migration/V0_0_0_2__add_status_attribute.sql
+++ b/src/main/resources/db/migration/V0_0_0_2__add_status_attribute.sql
@@ -1,0 +1,2 @@
+ALTER TABLE certificate ADD status VARCHAR2(255) NOT NULL DEFAULT 'Active';
+


### PR DESCRIPTION
## Description
Added Status attribute and cron job for setting correct type regarding _validFrom_ and _validUntil_ values every midnight. Value for status upon certificate insertion will be set regarding same logic of cron job.

Related to #74

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
