### PR TITLE
Fix(bpdm-certificate-management): Update migration script for status attribute and updated response mappings.

### DIFF
--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/dto/response/CertificateResponseDto.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/dto/response/CertificateResponseDto.kt
@@ -25,6 +25,7 @@ import org.eclipse.tractusx.bpdmcertificatemanagement.dto.EnclosedSiteDto
 import org.eclipse.tractusx.bpdmcertificatemanagement.dto.TrustLevelType
 import org.eclipse.tractusx.bpdmcertificatemanagement.dto.TrustValidatorDto
 import org.eclipse.tractusx.bpdmcertificatemanagement.dto.openapidescription.CommonDescription
+import org.eclipse.tractusx.bpdmcertificatemanagement.dto.StatusType
 import java.time.Instant
 import java.time.ZonedDateTime
 
@@ -41,6 +42,7 @@ data class CertificateResponseDto(
     val trustLevel: TrustLevelType,
     val validator: TrustValidatorDto? = null,
     val uploader: String? = null,
+    val status: StatusType,
 
     @get:Schema(description = CommonDescription.createdAt)
     val createdAt: Instant,

--- a/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/service/CertificateMapping.kt
+++ b/src/main/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/service/CertificateMapping.kt
@@ -128,6 +128,7 @@ class CertificateMapping {
             trustLevel = entity.trustLevel,
             validator = entity.validator?.let { toTrustValidatorDto(it) },
             uploader = entity.uploader,
+            status = entity.status,
             createdAt = entity.createdAt,
             updatedAt = entity.updatedAt
         )

--- a/src/main/resources/db/migration/V0_0_0_2__add_status_attribute.sql
+++ b/src/main/resources/db/migration/V0_0_0_2__add_status_attribute.sql
@@ -1,2 +1,2 @@
-ALTER TABLE certificate ADD status VARCHAR2(255) NOT NULL DEFAULT 'Active';
+ALTER TABLE certificate ADD status VARCHAR(255) NOT NULL DEFAULT 'Active';
 

--- a/src/test/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/data/CertificateTestValues.kt
+++ b/src/test/kotlin/org/eclipse/tractusx/bpdmcertificatemanagement/data/CertificateTestValues.kt
@@ -61,6 +61,7 @@ object CertificateTestValues {
         trustLevel = TrustLevelType.None,
         validator = TrustValidatorDto("NameTest01", "BPNL00000001TEST"),
         uploader = "BPNL00000001TEST",
+        status = StatusType.Active,
         createdAt = Instant.now(),
         updatedAt = Instant.now()
     )


### PR DESCRIPTION

## Description
In this pull request, we are updating migration script for status attribute where we could not use VARCHAR2 as per flyway configuration. Also, added status attribute for certificate response entity while querying with BPN and Certificate Type.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
