### PR TITLE
Feat(bpdm-certificate-management): Updated java version for application

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,7 +12,7 @@ To run the project first you need to install it from the parent pom. For that go
 ### Prerequisites
 
 * Maven
-* JDK17
+* JDK21
 
 
 ## NOTICE

--- a/docker/DOCKER_NOTICE.md
+++ b/docker/DOCKER_NOTICE.md
@@ -16,7 +16,7 @@ Eclipse Tractus-X product(s) installed within the image:
 
 **Used base image**
 
-- [eclipse-temurin:17-jre-alpine](https://github.com/adoptium/containers)
+- [eclipse-temurin:21-jre-alpine](https://github.com/adoptium/containers)
 - Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
 - Eclipse Temurin Project: https://projects.eclipse.org/projects/adoptium.temurin
 - Additional information about the Eclipse Temurin images: https://github.com/docker-library/repo-info/tree/master/repos/eclipse-temurin
@@ -32,6 +32,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 - SPDX-License-Identifier: Apache-2.0
-- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
-- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- SPDX-FileCopyrightText: 2023,2024 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2024 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/bpdm-certificate-management

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,9 @@
-FROM maven:3.8.7-eclipse-temurin-17 AS build
+FROM maven:3.9-eclipse-temurin-21-alpine AS build
 COPY . /home/app
 WORKDIR /home/app
 RUN mvn clean package -DskipTests
 
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:21-jre-alpine
 # Adding wget for the health check
 RUN apk --no-cache add wget
 COPY --from=build /home/app/target/bpdm-certificate-management.jar /usr/local/lib/bpdmCertificate/app.jar

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <description>bpdm-certificate-management</description>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
         <kotlin.version>1.8.22</kotlin.version>
         <springdoc.version>2.1.0</springdoc.version>
         <kotlinlogging.version>2.1.23</kotlinlogging.version>


### PR DESCRIPTION
## Description
In this pull request, we are updating java version for bpdm certificate management application. Here, we are updating java version from 17 to 21. The Base image will be eclipse-temurin:21-jre-alpine from now on.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
